### PR TITLE
OVS-2795 - Removed ':' and '.' from folder names, because crappy Wind…

### DIFF
--- a/ci/tests/general/general.py
+++ b/ci/tests/general/general.py
@@ -905,6 +905,6 @@ def validate_vpool_cleanup(vpool_name):
 
 
 def create_testsuite_screenshot_dir(testsuite):
-    dir_name = '/var/tmp/{0}_{1}'.format(testsuite, str(datetime.datetime.fromtimestamp(time.time())).replace(" ", "_"))
+    dir_name = '/var/tmp/{0}_{1}'.format(testsuite, str(datetime.datetime.fromtimestamp(time.time())).replace(" ", "_").replace(":", "_").replace(".", "_"))
     execute_command(command='mkdir {0}'.format(dir_name))
     return dir_name

--- a/ci/tests/gui/browser_ovs.py
+++ b/ci/tests/gui/browser_ovs.py
@@ -100,7 +100,7 @@ class BrowserOvs:
 
     def take_screenshot(self, name):
         location = self.screens_location
-        timestamp = str(datetime.datetime.fromtimestamp(time.time())).replace(" ", "_")
+        timestamp = str(datetime.datetime.fromtimestamp(time.time())).replace(" ", "_").replace(":", "_").replace(".", "_")
         if general.screenshot_dir is not None:
             if general.current_test is not None:
                 location = os.path.join(self.screens_location, general.screenshot_dir, general.current_test)


### PR DESCRIPTION
…ows makes that notation unreadable