### PR TITLE
AT-266 - update get_package_info to retrieve dedupe and non-dedupe vo…

### DIFF
--- a/ci/autotests.py
+++ b/ci/autotests.py
@@ -552,7 +552,7 @@ def _get_package_info():
     """
     Retrieve package information for installation
     """
-    command = "dpkg-query -W -f='${binary:Package} ${Version}\t${Description}\n' | grep 'openvstorage\|volumedriver-base\|alba \|arakoon\|python-celery '"
+    command = "dpkg-query -W -f='${binary:Package} ${Version}\t${Description}\n' | grep '^openvstorage\|^volumedriver\|^alba\|^arakoon\|^python-celery'"
 
     child_process = subprocess.Popen(command, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE)


### PR DESCRIPTION
output:

```
In [2]: autotests._get_package_info().splitlines()
Out[2]: 
['alba 0.9.13\tthe ALternative BAckend',
 'arakoon 1.9.7\tSimple consistent distributed key/value store',
 'openvstorage 2.7.1-rev.3746.3e222d4-1\topenvStorage',
 'openvstorage-backend 1.7.1-rev.635.b81d605-1\topenvStorage Backend plugin',
 'openvstorage-backend-core 1.7.1-rev.635.b81d605-1\topenvStorage Backend plugin core',
 'openvstorage-backend-webapps 1.7.1-rev.635.b81d605-1\topenvStorage Backend plugin Web Applications',
 'openvstorage-cinder-plugin 1.2.1-rev.27.073c037-1\tOpenvStorage Cinder plugin for OpenStack',
 'openvstorage-core 2.7.1-rev.3746.3e222d4-1\topenvStorage core',
 'openvstorage-hc 1.7.1-rev.635.b81d605-1\topenvStorage Backend plugin HyperConverged',
 'openvstorage-sdm 1.6.1-rev.325.0ff6839-1\tOpen vStorage Backend ASD Manager',
 'openvstorage-test 2.7.1-rev.934.75d7c56-1\topenvStorage autotest suite',
 'openvstorage-webapps 2.7.1-rev.3746.3e222d4-1\topenvStorage Web Applications',
 'python-celery 3.1.18-1ubuntu1\tasync task/job queue based on message passing (Python2 version)',
 'python-celery-common 3.1.18-1ubuntu1\tasync task/job queue based on message passing (common files)',
 'volumedriver-no-dedup-base 6.0.1-dev.201607041405.f07e34a\tVolumeDriver common infrastructure',
 'volumedriver-no-dedup-server 6.0.1-dev.201607041405.f07e34a\tVolumeDriver daemon and helpers']
```