### PR TITLE
losetup removal

### DIFF
--- a/ci/tests/general/general_vdisk.py
+++ b/ci/tests/general/general_vdisk.py
@@ -67,22 +67,16 @@ class GeneralVDisk(object):
         try:
             if loop_device is not None:
                 root_client.run('umount /mnt/{0} | echo true'.format(loop_device))
-                root_client.run('losetup -d /dev/{0} | echo true'.format(loop_device))
-                root_client.run('rm {0} | echo true'.format(location))
                 root_client.run('truncate -s {0}G {1}'.format(size, location))
-                root_client.run('losetup /dev/{0} {1}'.format(loop_device, location))
                 root_client.dir_create('/mnt/{0}'.format(loop_device))
-                root_client.run('parted /dev/{0} mklabel gpt'.format(loop_device))
-                root_client.run('parted -a optimal /dev/{0} mkpart primary ext4 0% 100%'.format(loop_device))
-                root_client.run('partprobe; echo true')
-                root_client.run('mkfs.ext4 /dev/{0}'.format(loop_device))
-                root_client.run('mount -t ext4 /dev/{0} /mnt/{0}'.format(loop_device))
+                root_client.run('mkfs.ext4 -F {0}'.format(location))
+                root_client.run('mount -o loop {0} /mnt/{1} '.format(location, loop_device))
             else:
                 root_client.run('truncate -s {0}G {1}'.format(size, location))
         except CalledProcessError as cpe:
             GeneralVDisk.logger.error(str(cpe))
             if loop_device is not None:
-                root_client.run("""umount /mnt/{0}; losetup -d /dev/{0}; rm {1}""".format(loop_device, location))
+                root_client.run("""umount /mnt/{0}; rm {1}; rmdir /mnt/{0}""".format(loop_device, location))
             raise
 
         vdisk = None
@@ -150,14 +144,11 @@ class GeneralVDisk(object):
 
             try:
                 if loop_device is not None:
-                    root_client.run('losetup /dev/{0} {1}'.format(loop_device, location))
                     root_client.dir_create('/mnt/{0}'.format(loop_device))
-                    root_client.run('mount -t ext4 /dev/{0} /mnt/{0}'.format(loop_device))
+                    root_client.run('mount -o loop {0} /mnt/{1}'.format(location, loop_device))
             except CalledProcessError as cpe:
                 GeneralVDisk.logger.error(str(cpe))
-                cmd = """umount /mnt/{0}; losetup -d /dev/{0}; rmdir /mnt/{0}""".format(loop_device)
-                root_client.run(cmd)
-                # raise
+                root_client.run("""umount /mnt/{0}; rmdir /mnt/{0}""".format(loop_device))
 
     @staticmethod
     def disconnect_volume(loop_device, root_client=None):
@@ -172,12 +163,11 @@ class GeneralVDisk(object):
 
         try:
             if loop_device is not None:
-                root_client.run('umount /mnt/{0}; losetup -d /dev/{0}; rmdir /mnt/{0}'.format(loop_device))
+                root_client.run("""umount /mnt/{0}; rmdir /mnt/{0}""".format(loop_device))
             else:
                 root_client.run('rmdir /mnt/{0}'.format(loop_device))
         except CalledProcessError as cpe:
             GeneralVDisk.logger.error(str(cpe))
-            # raise
 
     @staticmethod
     def write_to_volume(vdisk=None, vpool=None, location=None, count=1024, bs='1M', input_type='random',


### PR DESCRIPTION
Test results:

```
In [2]: autotests.run('ci.tests.vdisk')
nose.config: INFO: Set working dir to /opt/OpenvStorage/ci/tests
nose.config: INFO: Working directory /opt/OpenvStorage/ci/tests is a package; adding to sys.path
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
ci.tests.vdisk.vdisk_test.TestVDisk.ovs_3756_metadata_size_test ... ok
ci.tests.vdisk.vdisk_test.TestVDisk.ovs_3791_validate_backend_sync_test ... ok
ci.tests.vdisk.vdisk_test.TestVDisk.validate_clone_disk_test ... 2016-10-11 15:21:07 54800 +0200 - e191-1 - 106403/139759867025216 - lib/vdisk - 0 - INFO - clone_disk_test - create initial snapshot
2016-10-11 15:21:08 65900 +0200 - e191-1 - 106403/139759867025216 - lib/vdisk - 1 - INFO - clone_disk_test - create 1st 5.0 GB test file
2016-10-11 15:23:07 31000 +0200 - e191-1 - 106403/139759867025216 - lib/vdisk - 2 - INFO - clone_disk_test - create 2nd 5.0 GB test file
2016-10-11 15:25:21 34400 +0200 - e191-1 - 106403/139759867025216 - lib/vdisk - 3 - INFO - ('', '', 0)
2016-10-11 15:25:21 34400 +0200 - e191-1 - 106403/139759867025216 - lib/vdisk - 4 - INFO - clone_disk_test - cloning disk
2016-10-11 15:26:16 52000 +0200 - e191-1 - 106403/139759867025216 - lib/vdisk - 5 - INFO - Status of cloning disk task: True
2016-10-11 15:26:16 52000 +0200 - e191-1 - 106403/139759867025216 - lib/vdisk - 6 - INFO - Result of cloning disk task: {u'backingdevice': u'/new-cloned-disk.raw', u'vdisk_guid': u'5d0e2666-1fbc-4887-80e5-0a53497fdb11', u'name': u'new-cloned-disk'}
2016-10-11 15:26:16 52000 +0200 - e191-1 - 106403/139759867025216 - lib/vdisk - 7 - INFO - clone_disk_test - cloned disk
ok

----------------------------------------------------------------------
Ran 3 tests in 781.270s

OK
```
