### PR TITLE
Added support for init(upstart) and systemd

### DIFF
--- a/ci/tests/api/extended_test.py
+++ b/ci/tests/api/extended_test.py
@@ -20,7 +20,7 @@ Extended testsuite
 
 import os
 import time
-from ci.tests.general.general import General
+from ci.tests.general.general_system import GeneralSystem
 from ci.tests.general.logHandler import LogHandler
 
 logger = LogHandler.get('api', name='setup')
@@ -48,10 +48,7 @@ class TestExtended(object):
 
         non_running_services = ''
         while wait_time > 0:
-            out = General.execute_command_on_node(rebooted_host, "initctl list | grep ovs-*")
-            statuses = out.splitlines()
-
-            non_running_services = [s for s in statuses if 'start/running' not in s]
+            non_running_services = GeneralSystem.list_non_running_ovs_services(rebooted_host)
             if len(non_running_services) == 0:
                 break
 

--- a/ci/tests/general/general_system.py
+++ b/ci/tests/general/general_system.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2016 iNuron NV
+#
+# This file is part of Open vStorage Open Source Edition (OSE),
+# as available from
+#
+#      http://www.openvstorage.org and
+#      http://www.openvstorage.com.
+#
+# This file is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+# as published by the Free Software Foundation, in version 3 as it comes
+# in the LICENSE.txt file of the Open vStorage OSE distribution.
+#
+# Open vStorage is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY of any kind.
+
+"""
+A general class dedicated to Service and ServiceType logic
+"""
+
+from ci.tests.general.general import General
+
+
+class GeneralSystem(object):
+    """
+    A general class dedicated to system service logic
+    Support for init(upstart) / systemd
+    """
+
+    INIT_SYSTEM = General.execute_command_on_node('127.0.0.1', 'cat /proc/1/comm')
+    if INIT_SYSTEM not in ['init', 'systemd']:
+        raise RuntimeError('Unsupported init system: {0}'.format(INIT_SYSTEM))
+
+    @staticmethod
+    def list_ovs_services(host='127.0.0.1'):
+        if GeneralSystem.INIT_SYSTEM == 'init':
+            return General.execute_command_on_node(host, "initctl list | grep ovs-*").splitlines()
+        elif GeneralSystem.INIT_SYSTEM == 'systemd':
+            return General.execute_command_on_node(host, "systemctl -l | grep ovs-").splitlines()
+
+    @staticmethod
+    def list_running_ovs_services(host='127.0.0.1'):
+        if GeneralSystem.INIT_SYSTEM == 'init':
+            return [s for s in GeneralSystem.list_ovs_services(host) if 'start/running' in s]
+        elif GeneralSystem.INIT_SYSTEM == 'systemd':
+            return [s for s in GeneralSystem.list_ovs_services(host) if 'loaded active' in s]
+
+    @staticmethod
+    def list_non_running_ovs_services(host='127.0.0.1'):
+        if GeneralSystem.INIT_SYSTEM == 'init':
+            return [s for s in GeneralSystem.list_ovs_services(host) if 'start/running' not in s]
+        elif GeneralSystem.INIT_SYSTEM == 'systemd':
+            return [s for s in GeneralSystem.list_ovs_services(host) if 'loaded active' not in s]

--- a/ci/tests/general/general_system.py
+++ b/ci/tests/general/general_system.py
@@ -27,26 +27,27 @@ class GeneralSystem(object):
     Support for init(upstart) / systemd
     """
 
-    INIT_SYSTEM = General.execute_command_on_node('127.0.0.1', 'cat /proc/1/comm')
+    IP = General.get_config().get('main', 'grid_ip')
+    INIT_SYSTEM = General.execute_command_on_node(IP, 'cat /proc/1/comm')
     if INIT_SYSTEM not in ['init', 'systemd']:
         raise RuntimeError('Unsupported init system: {0}'.format(INIT_SYSTEM))
 
     @staticmethod
-    def list_ovs_services(host='127.0.0.1'):
+    def list_ovs_services(host=IP):
         if GeneralSystem.INIT_SYSTEM == 'init':
             return General.execute_command_on_node(host, "initctl list | grep ovs-*").splitlines()
         elif GeneralSystem.INIT_SYSTEM == 'systemd':
             return General.execute_command_on_node(host, "systemctl -l | grep ovs-").splitlines()
 
     @staticmethod
-    def list_running_ovs_services(host='127.0.0.1'):
+    def list_running_ovs_services(host=IP):
         if GeneralSystem.INIT_SYSTEM == 'init':
             return [s for s in GeneralSystem.list_ovs_services(host) if 'start/running' in s]
         elif GeneralSystem.INIT_SYSTEM == 'systemd':
             return [s for s in GeneralSystem.list_ovs_services(host) if 'loaded active' in s]
 
     @staticmethod
-    def list_non_running_ovs_services(host='127.0.0.1'):
+    def list_non_running_ovs_services(host=IP):
         if GeneralSystem.INIT_SYSTEM == 'init':
             return [s for s in GeneralSystem.list_ovs_services(host) if 'start/running' not in s]
         elif GeneralSystem.INIT_SYSTEM == 'systemd':

--- a/ci/tests/sanity/sanity_checks_test.py
+++ b/ci/tests/sanity/sanity_checks_test.py
@@ -19,6 +19,7 @@ Sanity check testsuite
 """
 
 from ci.tests.general.general import General
+from ci.tests.general.general_system import GeneralSystem
 from ci.tests.general.general_storagerouter import GeneralStorageRouter
 from ovs.extensions.generic.configuration import Configuration
 from ovs.extensions.generic.sshclient import SSHClient
@@ -35,12 +36,13 @@ class TestSanity(object):
         """
         issues_found = []
         env_ips = GeneralStorageRouter.get_all_ips()
-        for env_ip_connecting_from in env_ips:
-            out = General.execute_command_on_node(env_ip_connecting_from, "cat ~/.ssh/known_hosts")
-            for env_ip_connecting_to in env_ips:
-                if env_ip_connecting_from != env_ip_connecting_to:
-                    if env_ip_connecting_to not in out:
-                        issues_found.append('Host key verification not found between {0} and {1}'.format(env_ip_connecting_from, env_ip_connecting_to))
+        for env_ip_from in env_ips:
+            out = General.execute_command_on_node(env_ip_from, "cat ~/.ssh/known_hosts")
+            for env_ip_to in env_ips:
+                if env_ip_from != env_ip_to:
+                    if env_ip_to not in out:
+                        issues_found.append('Host key verification not found between {0} and {1}'.format(env_ip_from,
+                                                                                                         env_ip_to))
 
         assert len(issues_found) == 0, 'Following issues were found:\n - {0}'.format('\n - '.join(issues_found))
 
@@ -49,18 +51,13 @@ class TestSanity(object):
         """
         Verify some services
         """
-        # get env ips
         env_ips = GeneralStorageRouter.get_all_ips()
         non_running_services = []
 
         for env_ip in env_ips:
-            non_running_services_on_node = []
-            out = General.execute_command_on_node(env_ip, "initctl list | grep ovs-*")
-            statuses = out.splitlines()
-
-            non_running_services_on_node.extend([s for s in statuses if 'start/running' not in s])
-            if len(non_running_services_on_node):
-                non_running_services.append([env_ip, non_running_services_on_node])
+            non_running_services = GeneralSystem.list_non_running_ovs_services(env_ip)
+            if len(non_running_services):
+                non_running_services.append([env_ip, non_running_services])
 
         assert len(non_running_services) == 0, "Found non running services on {0}".format(non_running_services)
 
@@ -73,10 +70,6 @@ class TestSanity(object):
             "nginx": """ps -efx|grep nginx|grep -v grep""",
             "rabbitmq-server": """ps -ef|grep rabbitmq-|grep -v grep""",
             "memcached": """ps -ef|grep memcached|grep -v grep""",
-            "ovs-arakoon-ovsdb": """initctl list| grep ovsdb""",
-            "ovs-support-agent": """initctl list| grep support""",
-            "ovs-volumerouter-consumer": """initctl list| grep volumerou""",
-            "ovs-watcher-framework": """initctl list| grep watcher-fr"""
         }
 
         errors = ''
@@ -95,8 +88,11 @@ class TestSanity(object):
                 else:
                     errors += "Couldn't find {0} running process\n".format(service_to_check)
 
-        print services_checked
-        assert len(errors) == 0, "Found the following errors while checking for the system services:{0}\n".format(errors)
+        for non_running_service in GeneralSystem.list_non_running_ovs_services(grid_ip):
+            errors += str(non_running_service)
+
+        assert len(errors) == 0,\
+            "Found the following errors while checking for the system services:{0}\n".format(errors)
 
     @staticmethod
     def config_files_check_test():
@@ -111,7 +107,7 @@ class TestSanity(object):
         }
 
         for key_to_check in config_keys:
-            if not Configuration.exists(key_to_check, raw = True):
+            if not Configuration.exists(key_to_check, raw=True):
                 issues_found += "Couldn't find {0}\n".format(key_to_check)
 
         config_files = {
@@ -124,7 +120,8 @@ class TestSanity(object):
             if not client.file_exists(config_files[config_file_to_check]):
                 issues_found += "Couldn't find {0}\n".format(config_file_to_check)
 
-        assert issues_found == '', "Found the following issues while checking for the config files:{0}\n".format(issues_found)
+        assert issues_found == '',\
+            "Found the following issues while checking for the config files:{0}\n".format(issues_found)
 
     @staticmethod
     def json_files_check_test():
@@ -135,8 +132,10 @@ class TestSanity(object):
 
         srs = GeneralStorageRouter.get_storage_routers()
         for sr in srs:
-            config_contents = Configuration.get('/ovs/framework/hosts/{0}/setupcompleted'.format(sr.machine_id), raw = True)
+            config_contents = Configuration.get('/ovs/framework/hosts/{0}/setupcompleted'.format(sr.machine_id),
+                                                raw=True)
             if "true" not in config_contents:
                 issues_found += "Setup not completed for node {0}\n".format(sr.name)
 
-        assert issues_found == '', "Found the following issues while checking for the setupcompleted:{0}\n".format(issues_found)
+        assert issues_found == '',\
+            "Found the following issues while checking for the setupcompleted:{0}\n".format(issues_found)


### PR DESCRIPTION
ubuntu14.04 - 10.100.191.31:
```
In [2]: autotests.run('ci.tests.sanity')
nose.config: INFO: Set working dir to /opt/OpenvStorage/ci/tests
nose.config: INFO: Working directory /opt/OpenvStorage/ci/tests is a package; adding to sys.path
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
ci.tests.sanity.sanity_checks_test.TestSanity.config_files_check_test ... ok
ci.tests.sanity.sanity_checks_test.TestSanity.json_files_check_test ... ok
ci.tests.sanity.sanity_checks_test.TestSanity.services_check_test ... ok
ci.tests.sanity.sanity_checks_test.TestSanity.ssh_check_test ... ok
ci.tests.sanity.sanity_checks_test.TestSanity.system_services_check_test ... 2016-10-12 11:13:01 69800 +0200 - e191-1 - 111522/139723204454208 - extensions/sshclient - 0 - DEBUG - stdout: 7066 ?        Ss     0:00 nginx: master process /usr/sbin/nginx ocess /usr/sbin/nginx
2016-10-12 11:13:01 69900 +0200 - e191-1 - 111522/139723204454208 - extensions/sshclient - 1 - DEBUG - stderr: 
2016-10-12 11:13:01 71900 +0200 - e191-1 - 111522/139723204454208 - extensions/sshclient - 2 - DEBUG - stdout: memcache  20059      1  0 03:19 ?        00:00:08 /usr/bin/memcached -v -m 1024 -p 11211 -u memcache -l 0.0.0.0
2016-10-12 11:13:01 71900 +0200 - e191-1 - 111522/139723204454208 - extensions/sshclient - 3 - DEBUG - stderr: 
2016-10-12 11:13:01 73900 +0200 - e191-1 - 111522/139723204454208 - extensions/sshclient - 4 - DEBUG - stdout: rabbitmq  16104      1  0 03:06 ?        00:00:00 /bin/sh /usr/sbin/rabbitmq-server
2016-10-12 11:13:01 74000 +0200 - e191-1 - 111522/139723204454208 - extensions/sshclient - 5 - DEBUG - stderr: 
ok

----------------------------------------------------------------------
Ran 5 tests in 1.387s

OK
```

ubuntu16.04 - 10.100.192.31:

```
In [2]: autotests.run('ci.tests.sanity')
nose.config: INFO: Set working dir to /opt/OpenvStorage/ci/tests
nose.config: INFO: Working directory /opt/OpenvStorage/ci/tests is a package; adding to sys.path
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
Verify some configuration files ... ok
Verify some configuration files in json format ... ok
Verify some services ... ok
Verify SSH keys ... ok
Verify some system services ... 2016-10-12 11:27:18 69100 +0200 - e192-1 - 34889/139721968350976 - extensions/sshclient - 0 - DEBUG - stdout: 15237 ?        Ss     0:00 nginx: master process /usr/sbin/nginx -g daemon on; master_process on; n; master_process on;
2016-10-12 11:27:18 69100 +0200 - e192-1 - 34889/139721968350976 - extensions/sshclient - 1 - DEBUG - stderr: 
2016-10-12 11:27:18 70900 +0200 - e192-1 - 34889/139721968350976 - extensions/sshclient - 2 - DEBUG - stdout: memcache  15518      1  0 09:14 ?        00:00:02 /usr/bin/memcached -v -m 1024 -p 11211 -u memcache -l 0.0.0.0
2016-10-12 11:27:18 70900 +0200 - e192-1 - 34889/139721968350976 - extensions/sshclient - 3 - DEBUG - stderr: 
2016-10-12 11:27:18 72600 +0200 - e192-1 - 34889/139721968350976 - extensions/sshclient - 4 - DEBUG - stdout: rabbitmq  23991      1  0 Oct11 ?        00:00:00 /bin/sh /usr/sbin/rabbitmq-server
rabbitmq  24001  23991  0 Oct11 ?        00:00:00 /bin/sh -e /usr/lib/rabbitmq/bin/rabbitmq-server
2016-10-12 11:27:18 72700 +0200 - e192-1 - 34889/139721968350976 - extensions/sshclient - 5 - DEBUG - stderr: 
ok

----------------------------------------------------------------------
Ran 5 tests in 1.648s

OK

```