### PR TITLE
Ubuntu16.04 updates for disklayout test suite

### DIFF
--- a/ci/tests/disklayout/disk_roles_test.py
+++ b/ci/tests/disklayout/disk_roles_test.py
@@ -215,7 +215,6 @@ class TestDiskRoles(object):
         # End input validation
 
         # Start setup
-        collection = {}
         if configuration:
             config = configuration
         else:

--- a/ci/tests/general/general_disk.py
+++ b/ci/tests/general/general_disk.py
@@ -93,7 +93,7 @@ class GeneralDisk(object):
         :return: List of disks not being used
         """
         # @TODO: Make this call possible on all nodes, not only on node executing the tests
-        all_disks = General.execute_command("""fdisk -l 2>/dev/null| awk '/Disk \/.*:/ {gsub(":","",$s);print $2}'""")[0].splitlines()
+        all_disks = General.execute_command("""fdisk -l 2>/dev/null| awk '/Disk \/.*:/ {gsub(":","",$s);print $2}' | grep -v ram""")[0].splitlines()
         out = General.execute_command("df -h | awk '{print $1}'")[0]
 
         return [d for d in all_disks if d not in out and not 'mapper' in d and not General.execute_command("fuser {0}".format(d))[0]]


### PR DESCRIPTION
Test results on 10.100.192.31:

```
In [3]: autotests.run('ci.tests.disklayout')                
nose.config: INFO: Set working dir to /opt/OpenvStorage/ci/tests
nose.config: INFO: Working directory /opt/OpenvStorage/ci/tests is a package; adding to sys.path
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
This test will add a DB role to the sda disk of the storage router with the given IP ... ok
This test will append a DB role to the sda disk of the storage router with the given IP and remove all ... ok
FDL-0001 - disks in ovs model should match actual physical disk configuration ... ok
FDL-0002 - create/remove disk partition using full disk and verify ovs model ... ok

----------------------------------------------------------------------
Ran 4 tests in 149.123s

OK

```