### PR TITLE
Merge revamped rollbacktest

### DIFF
--- a/ci/scenarios/vDisk/rollback_vdisk_test/main.py
+++ b/ci/scenarios/vDisk/rollback_vdisk_test/main.py
@@ -1,0 +1,211 @@
+# Copyright (C) 2016 iNuron NV
+#
+# This file is part of Open vStorage Open Source Edition (OSE),
+# as available from
+#
+#      http://www.openvstorage.org and
+#      http://www.openvstorage.com.
+#
+# This file is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+# as published by the Free Software Foundation, in version 3 as it comes
+# in the LICENSE.txt file of the Open vStorage OSE distribution.
+#
+# Open vStorage is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY of any kind.
+
+import json
+import time
+import subprocess
+from ci.main import CONFIG_LOC
+from ci.helpers.api import OVSClient
+from ci.setup.vdisk import VDiskSetup
+from ci.helpers.vpool import VPoolHelper
+from ci.helpers.vdisk import VDiskHelper
+from ci.remove.vdisk import VDiskRemover
+from ovs.log.log_handler import LogHandler
+from ci.helpers.system import SystemHelper
+from ci.helpers.exceptions import VDiskNotFoundError
+from ovs.extensions.generic.sshclient import SSHClient
+
+
+class RollbackChecks(object):
+
+    CASE_TYPE = 'AT_QUICK'
+    LOGGER = LogHandler.get(source="scenario", name="ci_scenario_rollback")
+    SIZE_VDISK = 52428800
+    VDISK_NAME = "integration-tests-rollback"
+    MAX_ROLLBACK_CHECKS = 10
+    ROLLBACK_TIMEOUT = 45
+    WRITE_AMOUNT_OF_TIMES = 2
+    REQUIRED_PACKAGES = ['fio']
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def main(blocked):
+        """
+        Run all required methods for the test
+
+        :param blocked: was the test blocked by other test?
+        :type blocked: bool
+        :return: results of test
+        :rtype: dict
+        """
+        if not blocked:
+            try:
+                RollbackChecks.validate_rollback()
+                return {'status': 'PASSED', 'case_type': RollbackChecks.CASE_TYPE, 'errors': None}
+            except Exception as ex:
+                RollbackChecks.LOGGER.error("Scrubbing checks failed with error: {0}".format(str(ex)))
+                return {'status': 'FAILED', 'case_type': RollbackChecks.CASE_TYPE, 'errors': ex}
+        else:
+            return {'status': 'BLOCKED', 'case_type': RollbackChecks.CASE_TYPE, 'errors': None}
+
+    @staticmethod
+    def validate_rollback(size=SIZE_VDISK, amount_checks=MAX_ROLLBACK_CHECKS, timeout=ROLLBACK_TIMEOUT):
+        """
+        Validate if scrubbing works on a vpool
+
+        INFO: 1 vPool should be available on 1 storagerouter
+
+        :param size: size of a single vdisk in bytes
+        :type size: int
+        :param amount_checks: amount of times to check if stored data has changed
+        :type amount_checks: int
+        :param timeout: specify a timeout
+        :type timeout: int
+        :return:
+        """
+
+        RollbackChecks.LOGGER.info("Starting to validate the rollback")
+        with open(CONFIG_LOC, "r") as JSON_CONFIG:
+            config = json.load(JSON_CONFIG)
+
+        api = OVSClient(
+            config['ci']['grid_ip'],
+            config['ci']['user']['api']['username'],
+            config['ci']['user']['api']['password']
+        )
+
+        vpools = VPoolHelper.get_vpools()
+        assert len(vpools) >= 1, "Not enough vPools to test"
+
+        vpool = vpools[0]  # just pick the first vpool you find
+        assert len(vpool.storagedrivers) >= 1, "Not enough Storagedrivers to test"
+
+        # create vdisks and write some stuff on it
+        storagedriver = vpool.storagedrivers[0]  # just pick the first storagedriver you find
+        client = SSHClient(storagedriver.storage_ip, username='root')
+
+        # check for possible missing packages
+        missing_packages = SystemHelper.get_missing_packages(storagedriver.storage_ip,
+                                                             RollbackChecks.REQUIRED_PACKAGES)
+        assert len(missing_packages) == 0, "Missing {0} package(s) on `{1}`: {2}"\
+            .format(len(missing_packages), storagedriver.storage_ip, missing_packages)
+
+        RollbackChecks.LOGGER.info("Starting deploying vdisk `{0}`".format(RollbackChecks.VDISK_NAME))
+
+        # create a vdisk & collect results
+        vdisk_guid = VDiskSetup.create_vdisk(vdisk_name=RollbackChecks.VDISK_NAME + '.raw', vpool_name=vpool.name,
+                                             size=size, api=api, storagerouter_ip=storagedriver.storage_ip)
+        vdisk = VDiskHelper.get_vdisk_by_guid(vdisk_guid)
+        results = {'vdisk_guid': vdisk_guid, 'snapshots': {}}
+
+        RollbackChecks.LOGGER.info("Finished deploying vdisk `{0}`".format(RollbackChecks.VDISK_NAME))
+        RollbackChecks.LOGGER.info("Starting writing & snapshotting vdisk `{0}`".format(RollbackChecks.VDISK_NAME))
+
+        for i in xrange(RollbackChecks.WRITE_AMOUNT_OF_TIMES):
+            try:
+                RollbackChecks.LOGGER.info("Starting FIO on vdisk `{0}` write cycle {1}/{2}"
+                                           .format(RollbackChecks.VDISK_NAME, i+1,
+                                                   RollbackChecks.WRITE_AMOUNT_OF_TIMES))
+                # perform fio test
+                client.run(["fio", "--name=test",
+                            "--filename=/mnt/{0}/{1}.raw".format(vpool.name, RollbackChecks.VDISK_NAME),
+                            "--ioengine=libaio", "--iodepth=4", "--rw=write", "--bs=4k", "--direct=1",
+                            "--size={0}b".format(RollbackChecks.SIZE_VDISK)])
+                RollbackChecks.LOGGER.info("Finished FIO on vdisk `{0}` write cycle {1}/{2}"
+                                           .format(RollbackChecks.VDISK_NAME, i+1,
+                                                   RollbackChecks.WRITE_AMOUNT_OF_TIMES))
+
+            except subprocess.CalledProcessError as ex:
+                raise VDiskNotFoundError("VDisk `/mnt/{0}/{1}.raw` does not seem to be present "
+                                         "or has problems on storagerouter `{2}`: {3}"
+                                         .format(vpool.name, RollbackChecks.VDISK_NAME, storagedriver.storage_ip,
+                                                 ex.message))
+
+            RollbackChecks.LOGGER.info("Starting snapshot creation on vdisk `{0}`".format(RollbackChecks.VDISK_NAME))
+
+            # create snapshot
+            snapshot_guid = VDiskSetup.create_snapshot(snapshot_name=RollbackChecks.VDISK_NAME + '-snapshot{0}'
+                                                       .format(i), vdisk_name=RollbackChecks.VDISK_NAME + '.raw',
+                                                       vpool_name=vpool.name, api=api, consistent=False, sticky=False)
+            # save the current stored_data for comparison
+            stored_data = vdisk.storagedriver_client.info_volume(str(vdisk.volume_id)).stored
+            RollbackChecks.LOGGER.info("Logged `{0}` stored data for VDisk `{1}` in mapper"
+                                       .format(stored_data, RollbackChecks.VDISK_NAME))
+            # add details to snapshot mapper
+            results['snapshots'][i] = {'snapshot_guid': snapshot_guid,
+                                       'snapshot_name': RollbackChecks.VDISK_NAME + '-snapshot{0}'.format(i),
+                                       'stored_data': stored_data}
+
+            RollbackChecks.LOGGER.info("Snapshot creation finished on vdisk `{0}`".format(RollbackChecks.VDISK_NAME))
+
+        RollbackChecks.LOGGER.info("Finished writing & snapshotting vdisk `{0}`. Results: {1}"
+                                   .format(RollbackChecks.VDISK_NAME, results))
+
+        # Commencing rollback
+        RollbackChecks.LOGGER.info("Starting rollback on vdisk `{0}` to first snapshot `{1}`"
+                                   .format(RollbackChecks.VDISK_NAME, results['snapshots'][0]))
+        VDiskSetup.rollback_to_snapshot(vdisk_name=RollbackChecks.VDISK_NAME + '.raw',
+                                        vpool_name=vpool.name, snapshot_id=results['snapshots'][0]['snapshot_guid'],
+                                        api=api)
+
+        # Start checking when disk is rollback'ed
+        tries = 0
+        while tries < amount_checks:
+            current_statistics = vdisk.storagedriver_client.info_volume(str(vdisk.volume_id)).stored
+            if current_statistics < results['snapshots'][1]['stored_data']:
+                RollbackChecks.LOGGER.info("VDisk `{0}` matched the requirements for rollback with {1} < {2}"
+                                           .format(vdisk_guid, current_statistics,
+                                                   results['snapshots'][1]['stored_data']))
+                break
+            else:
+                tries += 1
+                RollbackChecks.LOGGER.warning("Try `{0}` when checking stored data on volumedriver for VDisk "
+                                              "`{1}`, with currently `{2}` but it should be less than `{3}`. "
+                                              "Now sleeping for `{4}` seconds ..."
+                                              .format(tries, vdisk_guid, current_statistics,
+                                                      results['snapshots'][1]['stored_data'], timeout))
+                time.sleep(timeout)
+
+        # check if amount of tries has exceeded
+        if tries == amount_checks:
+            error_msg = "VDisk `{0}` should have been rollback'ed but max. amount of checks have exceeded!"\
+                .format(RollbackChecks.VDISK_NAME)
+            RollbackChecks.LOGGER.error(error_msg)
+            raise RuntimeError(error_msg)
+        else:
+            RollbackChecks.LOGGER.info("Successfully finished rollback'ing on vdisk `{0}`"
+                                       .format(RollbackChecks.VDISK_NAME))
+
+        # commencing deleting volumes
+        RollbackChecks.LOGGER.info("Starting to remove VDisk `{0}`".format(RollbackChecks.VDISK_NAME))
+        VDiskRemover.remove_vdisk(vdisk_guid)
+        RollbackChecks.LOGGER.info("Finished removing VDisk `{0}`".format(RollbackChecks.VDISK_NAME))
+
+
+def run(blocked=False):
+    """
+    Run a test
+
+    :param blocked: was the test blocked by other test?
+    :return: results of test
+    :rtype: dict
+    """
+    return RollbackChecks().main(blocked)
+
+if __name__ == "__main__":
+    run()

--- a/ci/scenarios/vDisk/rollback_vdisk_test/main.py
+++ b/ci/scenarios/vDisk/rollback_vdisk_test/main.py
@@ -58,7 +58,7 @@ class RollbackChecks(object):
                 RollbackChecks.validate_rollback()
                 return {'status': 'PASSED', 'case_type': RollbackChecks.CASE_TYPE, 'errors': None}
             except Exception as ex:
-                RollbackChecks.LOGGER.error("Scrubbing checks failed with error: {0}".format(str(ex)))
+                RollbackChecks.LOGGER.error("Rollback checks failed with error: {0}".format(str(ex)))
                 return {'status': 'FAILED', 'case_type': RollbackChecks.CASE_TYPE, 'errors': ex}
         else:
             return {'status': 'BLOCKED', 'case_type': RollbackChecks.CASE_TYPE, 'errors': None}

--- a/ci/scenarios/vmachine/perform_fio_test/main.py
+++ b/ci/scenarios/vmachine/perform_fio_test/main.py
@@ -68,7 +68,7 @@ class FioOnVDiskChecks(object):
 
         INFO:
             * 1 vPool should be available on 1 storagerouter
-            * Removes all tap-ctl connections with vdisk prefix equal to STATIC variable `FioOnVDiskChecks.PREFIX`
+            * Removes all tap-ctl connections with vdisk prefix equal to STATIC variable `FioOnVDiskChecks.VDISK_NAME`
 
         :param amount_vdisks: amount of vdisks to deploy and scrub
         :type amount_vdisks: int

--- a/ci/setup/vdisk.py
+++ b/ci/setup/vdisk.py
@@ -29,6 +29,7 @@ class VDiskSetup(object):
     CREATE_VDISK_TIMEOUT = 60
     CREATE_CLONE_TIMEOUT = 60
     SET_VDISK_AS_TEMPLATE_TIMEOUT = 60
+    ROLLBACK_VDISK_TIMEOUT = 60
 
     def __init__(self):
         pass
@@ -310,4 +311,41 @@ class VDiskSetup(object):
             raise RuntimeError(error_msg)
         else:
             VDiskSetup.LOGGER.info("Creating vTemplate `{0}` should have succeeded".format(vdisk_name))
+            return task_result[1]
+
+    @staticmethod
+    @required_vdisk
+    def rollback_to_snapshot(vdisk_name, vpool_name, snapshot_id, api, timeout=ROLLBACK_VDISK_TIMEOUT):
+        """
+        Rollback a vdisk to a certain snapshot
+
+        :param vdisk_name: location of a vdisk on a vpool
+                           (e.g. /mnt/vpool/test.raw = test.raw, /mnt/vpool/volumes/test.raw = volumes/test.raw )
+        :type vdisk_name: str
+        :param vpool_name: name of a existing vpool
+        :type vpool_name: str
+        :param snapshot_id: guid of a snapshot for the chosen vdisk
+        :type snapshot_id: str
+        :param api: specify a valid api connection to the setup
+        :type api: ci.helpers.api.OVSClient
+        :param timeout: time to wait for the task to complete
+        """
+
+        # fetch the requirements
+        vdisk_guid = VDiskHelper.get_vdisk_by_name(vdisk_name=vdisk_name, vpool_name=vpool_name).guid
+        snapshot = VDiskHelper.get_snapshot_by_guid(snapshot_guid=snapshot_id, vdisk_name=vdisk_name,
+                                                    vpool_name=vpool_name)
+
+        task_guid = api.post(
+            api='/vdisks/{0}/rollback'.format(vdisk_guid),
+            data={"timestamp": snapshot['timestamp']}
+        )
+        task_result = api.wait_for_task(task_id=task_guid, timeout=timeout)
+
+        if not task_result[0]:
+            error_msg = "Rollback vDisk `{0}` has failed with error {1}".format(vdisk_name, task_result[1])
+            VDiskSetup.LOGGER.error(error_msg)
+            raise RuntimeError(error_msg)
+        else:
+            VDiskSetup.LOGGER.info("Rollback vDisk `{0}` should have succeeded".format(vdisk_name))
             return task_result[1]


### PR DESCRIPTION
The output of the test is this:
```
In [4]: autotests.run(['ci.scenarios.vDisk.rollback_vdisk_test'], send_to_testrail=True)
{u'status': u'STARTED', u'successful': False, u'failed': False, u'result': u"{'hostname': 'celery@ovs-node01-1604', 'pid': 16488}", u'ready': False, u'id': u'23ffa6c4-4492-40ef-b53c-74bb1bb61350'}
{u'status': u'STARTED', u'successful': False, u'failed': False, u'result': u"{'hostname': 'celery@ovs-node01-1604', 'pid': 16488}", u'ready': False, u'id': u'23ffa6c4-4492-40ef-b53c-74bb1bb61350'}
{u'status': u'STARTED', u'successful': False, u'failed': False, u'result': u"{'hostname': 'celery@ovs-node01-1604', 'pid': 16488}", u'ready': False, u'id': u'23ffa6c4-4492-40ef-b53c-74bb1bb61350'}
{u'status': u'STARTED', u'successful': False, u'failed': False, u'result': u"{'hostname': 'celery@ovs-node02-1604', 'pid': 7093}", u'ready': False, u'id': u'0ea7147f-5210-46b8-aa51-d9547ca8bc87'}
{u'status': u'STARTED', u'successful': False, u'failed': False, u'result': u"{'hostname': 'celery@ovs-node03-1604', 'pid': 11527}", u'ready': False, u'id': u'462747fa-00f0-4369-9bd2-63fd460611c7'}
{u'status': u'STARTED', u'successful': False, u'failed': False, u'result': u"{'hostname': 'celery@ovs-node01-1604', 'pid': 16488}", u'ready': False, u'id': u'8c55fd5f-db26-4431-a212-9145b5da058f'}
Out[4]: 
({'ci.scenarios.vDisk.rollback_vdisk_test': {'case_type': 'AT_QUICK',
   'errors': None,
   'status': 'PASSED'}},
 u'http://testrail.openvstorage.com/index.php?/plans/view/35244')
```

Logs
```
2016-12-08 16:02:20 61600 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 35 - INFO - Starting to validate the rollback
2016-12-08 16:02:20 69400 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 36 - INFO - Starting deploying vdisk `integration-tests-rollback`
2016-12-08 16:02:23 95000 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 38 - INFO - Finished deploying vdisk `integration-tests-rollback`
2016-12-08 16:02:23 95100 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 39 - INFO - Starting writing & snapshotting vdisk `integration-tests-rollback`
2016-12-08 16:02:23 95100 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 40 - INFO - Starting FIO on vdisk `integration-tests-rollback` write cycle 1/2
2016-12-08 16:02:26 21000 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 41 - INFO - Finished FIO on vdisk `integration-tests-rollback` write cycle 1/2
2016-12-08 16:02:26 21000 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 42 - INFO - Starting snapshot creation on vdisk `integration-tests-rollback`
2016-12-08 16:02:27 33200 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 44 - INFO - Logged `52428800` stored data for VDisk `integration-tests-rollback` in mapper
2016-12-08 16:02:27 33200 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 45 - INFO - Snapshot creation finished on vdisk `integration-tests-rollback`
2016-12-08 16:02:27 33200 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 46 - INFO - Starting FIO on vdisk `integration-tests-rollback` write cycle 2/2
2016-12-08 16:02:29 76900 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 47 - INFO - Finished FIO on vdisk `integration-tests-rollback` write cycle 2/2
2016-12-08 16:02:29 76900 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 48 - INFO - Starting snapshot creation on vdisk `integration-tests-rollback`
2016-12-08 16:02:30 94100 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 50 - INFO - Logged `104857600` stored data for VDisk `integration-tests-rollback` in mapper
2016-12-08 16:02:30 94100 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 51 - INFO - Snapshot creation finished on vdisk `integration-tests-rollback`
2016-12-08 16:02:30 94100 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 52 - INFO - Finished writing & snapshotting vdisk `integration-tests-rollback`. Results: {'vdisk_guid': u'c0fc545a-cc7d-452c-b2ed-ecaf76b54770', 'snapshots': {0: {'snapshot_name': 'integration-tests-rollback-snapshot0', 'snapshot_guid': u'f365a73c-9be8-4e46-9037-23cc71e92620', 'stored_data': 52428800}, 1: {'snapshot_name': 'integration-tests-rollback-snapshot1', 'snapshot_guid': u'5e014383-6f5d-445d-b09e-e6eed029995c', 'stored_data': 104857600}}}
2016-12-08 16:02:30 94100 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 53 - INFO - Starting rollback on vdisk `integration-tests-rollback` to first snapshot `{'snapshot_name': 'integration-tests-rollback-snapshot0', 'snapshot_guid': u'f365a73c-9be8-4e46-9037-23cc71e92620', 'stored_data': 52428800}`
2016-12-08 16:02:32 21100 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 55 - INFO - VDisk `c0fc545a-cc7d-452c-b2ed-ecaf76b54770` matched the requirements for rollback with 52428800 < 104857600
2016-12-08 16:02:32 21100 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 56 - INFO - Successfully finished rollback'ing on vdisk `integration-tests-rollback`
2016-12-08 16:02:32 21100 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 57 - INFO - Starting to remove VDisk `integration-tests-rollback`
2016-12-08 16:02:32 32900 +0100 - ovs-node01-1604 - 16446/140594892519168 - scenario/ci_scenario_rollback - 61 - INFO - Finished removing VDisk `integration-tests-rollback`
```