### PR TITLE
Improve the healthcheck run, add nonblocking scenario setting and fix testrail messaging

### DIFF
--- a/ci/autotests.py
+++ b/ci/autotests.py
@@ -99,7 +99,12 @@ def run(scenarios=['ALL'], send_to_testrail=False, fail_on_failed_scenario=False
         # check if a test has failed, if it has failed check if we should block all other tests
         if hasattr(TestrailResult, module_result['status']):
             if getattr(TestrailResult, module_result['status']) == TestrailResult.FAILED and fail_on_failed_scenario:
-                blocked = True
+                if 'blocking' not in module_result:
+                    # if a test reports failed but blocked is not present = by default blocked == True
+                    blocked = True
+                elif module_result['blocking'] is not False:
+                    # if a test reports failed but blocked != False
+                    blocked = True
         else:
             raise AttributeError("Attribute `{0}` does not exists as status "
                                  "in TestrailResult".format(module_result['status']))
@@ -238,7 +243,7 @@ def push_to_testrail(results, config_path=TESTTRAIL_LOC, skip_on_no_results=True
             raise AttributeError("Attribute `{0}` does not exists as test_status in TestrailResult"
                                  .format(test_result['status']))
         # add results to test cases, if the've got something in the field `errors`
-        if not test_result['errors']:
+        if test_result['errors'] is not None:
             tapi.add_result(test_id, test_status_id, comment=str(test_result['errors']))
         else:
             tapi.add_result(test_id, test_status_id)

--- a/ci/scenarios/healthcheck/healthcheck_run_test/main.py
+++ b/ci/scenarios/healthcheck/healthcheck_run_test/main.py
@@ -47,7 +47,7 @@ class HealthCheckCI(object):
                 return {'status': 'PASSED', 'case_type': HealthCheckCI.CASE_TYPE, 'errors': result}
             except Exception as ex:
                 HealthCheckCI.LOGGER.error("Healthcheck CI testing failed with error: {0}".format(str(ex)))
-                return {'status': 'FAILED', 'case_type': HealthCheckCI.CASE_TYPE, 'errors': str(ex)}
+                return {'status': 'FAILED', 'case_type': HealthCheckCI.CASE_TYPE, 'errors': str(ex), 'blocking': False}
         else:
             return {'status': 'BLOCKED', 'case_type': HealthCheckCI.CASE_TYPE, 'errors': None}
 
@@ -115,9 +115,13 @@ class HealthCheckCI(object):
         from ovs.lib.healthcheck import HealthCheckController
 
         result = HealthCheckController.check_silent()
-        assert result is not None
-        assert 'result' in result
-        assert 'recap' in result
+        assert result is not None, 'No results found in the healthcheck output'
+        assert 'result' in result, 'the result section is missing in the healthcheck output'
+        assert 'recap' in result, 'the recap section is missing in the healthcheck output'
+        assert result['recap']['EXCEPTION'] == 0, '{0} exception(s) found during the healthcheck run: {1}'\
+            .format(result['recap']['EXCEPTION'], result)
+        assert result['recap']['FAILED'] == 0, '{0} failure(s) found during the healthcheck run: {1}'\
+            .format(result['recap']['FAILED'], result)
 
         HealthCheckCI.LOGGER.info("Finished validating the healthcheck")
 


### PR DESCRIPTION
This pull request improves and fixes the following items:
* Improvement of the healthcheck test (fails if EXCEPTIONS/FAILED messages are present)
* Added a non blocking setting: if a non blocking settings is specified on a certain scenario and that scenario fails it will not block the other tests: http://testrail.openvstorage.com/index.php?/plans/view/35364
* Fix that messages can be shipped to testrail even when the test has not failed: http://testrail.openvstorage.com/index.php?/tests/view/1140932&group_by=cases:section_id&group_order=asc&group_id=29894 & http://testrail.openvstorage.com/index.php?/tests/view/1141058&group_by=cases:section_id&group_order=asc&group_id=29894
* Remove the healthcheck from excluded mode because its now non blocking for other tests