### PR TITLE
AT-392 - ovs_3756_metadata_size_test intermittent failure

### DIFF
--- a/ci/tests/general/connection.py
+++ b/ci/tests/general/connection.py
@@ -192,13 +192,14 @@ class Connection(object):
         :return: Tuple containing a boolean if the task was successful or not and the result of the task
         """
         start = time.time()
-        task_metadata = {'ready': False}
-        while task_metadata['ready'] is False:
+        finished = False
+        while finished is False:
             if timeout is not None and timeout < (time.time() - start):
                 raise RuntimeError('Waiting for task {0} has timed out.'.format(task_id))
             task_metadata = self.fetch('tasks', task_id)
             print task_metadata
-            if task_metadata['ready'] is False:
+            finished = task_metadata['status'] in ('FAILURE', 'SUCCESS')
+            if finished is False:
                 time.sleep(1)
-
-        return task_metadata['successful'], task_metadata['result']
+            else:
+                return task_metadata['successful'], task_metadata['result']

--- a/ci/tests/general/general_vdisk.py
+++ b/ci/tests/general/general_vdisk.py
@@ -306,7 +306,7 @@ class GeneralVDisk(object):
         status, _ = GeneralVDisk.api.execute_post_action(component='vdisks', guid=vdisk.guid,
                                                          action='set_config_params', data=params, wait=True)
         assert status is True,\
-            'Retrieving config params failed: {0} for vdisk: {1} - {2}'.format(status, vdisk.name, params)
+            'Setting config params failed: {0} for vdisk: {1} - {2}'.format(status, vdisk.name, params)
 
     @staticmethod
     def schedule_backend_sync(vdisk):


### PR DESCRIPTION
task with state read == True can still fail on tasks with status PENDING/STARTED

added new logic used in fwk too ...

```
AssertionError: Retrieving config params failed: False for vdisk: ovs-3756-disk - {'hostname': 'celery@tenv191-node2', 'pid': 27023}
-------------------- >> begin captured stdout << ---------------------
38b95e36-96de-411c-8ca0-4a5260331473
{u'status': u'SUCCESS', u'successful': True, u'failed': False, u'result': {u'dtl_mode': u'a_sync', u'metadata_cache_size': 50331648, u'write_buffer': 128, u'dtl_target': [], u'sco_size': 4}, u'ready': True, u'id': u'38b95e36-96de-411c-8ca0-4a5260331473'}
0cc0e54e-7d74-4881-8b41-8971cc482244
{u'status': u'PENDING', u'successful': False, u'failed': False, u'result': None, u'ready': False, u'id': u'0cc0e54e-7d74-4881-8b41-8971cc482244'}
{u'status': u'SUCCESS', u'successful': True, u'failed': False, u'result': {u'dtl_mode': u'a_sync', u'metadata_cache_size': 50331648, u'write_buffer': 128, u'dtl_target': [], u'sco_size': 4}, u'ready': True, u'id': u'0cc0e54e-7d74-4881-8b41-8971cc482244'}
50e9d6f2-83dc-4c79-9657-2810fc527bdf
{u'status': u'SUCCESS', u'successful': True, u'failed': False, u'result': None, u'ready': True, u'id': u'50e9d6f2-83dc-4c79-9657-2810fc527bdf'}
e565e078-8e7d-48fa-8ad4-75bca8bdb097
{u'status': u'STARTED', u'successful': False, u'failed': False, u'result': u"{'hostname': 'celery@tenv191-node2', 'pid': 27023}", u'ready': True, u'id': u'e565e078-8e7d-48fa-8ad4-75bca8bdb097'}
```

