### PR TITLE
Fix for failing Configuration.get statement

### DIFF
--- a/ci/scenarios/arakoon/ar_0002_arakoon_cluster_validation_test/main.py
+++ b/ci/scenarios/arakoon/ar_0002_arakoon_cluster_validation_test/main.py
@@ -20,7 +20,7 @@ from ci.api_lib.helpers.storagerouter import StoragerouterHelper
 from ci.autotests import gather_results
 from ci.scenario_helpers.ci_constants import CIConstants
 from ovs_extensions.storage.persistent.pyrakoonstore import PyrakoonStore, KeyNotFoundException
-from ovs_extensions.generic.configuration import Configuration
+from ovs.extensions.generic.configuration import Configuration
 from ovs.extensions.generic.sshclient import SSHClient
 from ovs.extensions.services.servicefactory import ServiceFactory
 


### PR DESCRIPTION
Test result:

```
In [1]: from ci.autotests import AutoTests
In [2]: AutoTests.run('ci.scenarios.arakoon.ar_0002_arakoon_cluster_validation_test')
2017-07-03 15:34:14 23800 +0200 - ovs-node01-1604 - 4793/139652209723136 - autotests/ci_autotests - 0 - INFO - Collecting tests.
2017-07-03 15:34:14 23900 +0200 - ovs-node01-1604 - 4793/139652209723136 - autotests/ci_autotests - 1 - INFO - Executing the following tests: ['ci.scenarios.arakoon.ar_0002_arakoon_cluster_validation_test']
2017-07-03 15:34:14 23900 +0200 - ovs-node01-1604 - 4793/139652209723136 - autotests/ci_autotests - 2 - INFO - Starting tests.
2017-07-03 15:34:14 25600 +0200 - ovs-node01-1604 - 4793/139652209723136 - scenario/ci_scenario_arakoon_validation - 3 - INFO - Starting validating arakoon cluster
2017-07-03 15:34:14 28700 +0200 - ovs-node01-1604 - 4793/139652209723136 - dal/helper - 4 - INFO - Received object type <type 'unicode'> is not a hybrid
2017-07-03 15:34:14 30700 +0200 - ovs-node01-1604 - 4793/139652209723136 - scenario/ci_scenario_arakoon_validation - 5 - INFO - Validating if cluster service `ovsdb` is available on node `10.100.199.191`
2017-07-03 15:34:14 30800 +0200 - ovs-node01-1604 - 4793/139652209723136 - scenario/ci_scenario_arakoon_validation - 6 - INFO - Validating if cluster service `ovsdb` is running on node `10.100.199.191`
2017-07-03 15:34:14 31900 +0200 - ovs-node01-1604 - 4793/139652209723136 - dal/helper - 7 - INFO - Received object type <type 'unicode'> is not a hybrid
2017-07-03 15:34:14 67700 +0200 - ovs-node01-1604 - 4793/139652209723136 - scenario/ci_scenario_arakoon_validation - 8 - INFO - Validating if cluster service `ovsdb` is available on node `10.100.199.192`
2017-07-03 15:34:14 83900 +0200 - ovs-node01-1604 - 4793/139652209723136 - scenario/ci_scenario_arakoon_validation - 9 - INFO - Validating if cluster service `ovsdb` is running on node `10.100.199.192`
2017-07-03 15:34:14 97400 +0200 - ovs-node01-1604 - 4793/139652209723136 - dal/helper - 10 - INFO - Received object type <type 'unicode'> is not a hybrid
2017-07-03 15:34:15 44500 +0200 - ovs-node01-1604 - 4793/139652209723136 - scenario/ci_scenario_arakoon_validation - 11 - INFO - Validating if cluster service `ovsdb` is available on node `10.100.199.193`
2017-07-03 15:34:15 47100 +0200 - ovs-node01-1604 - 4793/139652209723136 - scenario/ci_scenario_arakoon_validation - 12 - INFO - Validating if cluster service `ovsdb` is running on node `10.100.199.193`
2017-07-03 15:34:15 62700 +0200 - ovs-node01-1604 - 4793/139652209723136 - scenario/ci_scenario_arakoon_validation - 13 - INFO - Validating if cluster `ovsdb` works
2017-07-03 15:34:15 76100 +0200 - ovs-node01-1604 - 4793/139652209723136 - scenario/ci_scenario_arakoon_validation - 14 - INFO - Finished validating arakoon cluster
2017-07-03 15:34:15 76100 +0200 - ovs-node01-1604 - 4793/139652209723136 - autotests/ci_autotests - 15 - INFO - Finished tests.
Out[2]: 
({'ci.scenarios.arakoon.ar_0002_arakoon_cluster_validation_test': {'case_type': 'FUNCTIONAL',
   'errors': None,
   'status': 'PASSED'}},
 None)
```
