### PR TITLE
MDS key was changed

### DIFF
--- a/ci/scenarios/vPool/mds_regression/main.py
+++ b/ci/scenarios/vPool/mds_regression/main.py
@@ -238,7 +238,7 @@ class RegressionTester(CIConstants):
                         vm_client = rem.SSHClient(vm_data['ip'], vm_username, vm_password)
                         vm_client.file_create('/mnt/data/{0}.raw'.format(vm_data['create_msg']))
                         vm_data['client'] = vm_client
-                    cls._set_mds_safety(1, checkup=True)  # Set the safety to trigger the mds
+                    cls._set_mds_safety(source_storagedriver.vpool, 1, checkup=True)  # Set the safety to trigger the mds
                     safety_set = True
                     io_thread_pairs, monitoring_data, io_r_semaphore = ThreadingHandler.start_io_polling_threads(volume_bundle=vdisk_info)
                     threads['evented']['io']['pairs'] = io_thread_pairs
@@ -262,7 +262,7 @@ class RegressionTester(CIConstants):
                     cls._delete_snapshots(volume_bundle=vdisk_info, api=api)
                     # Start scrubbing thread
                     async_scrubbing = cls.start_scrubbing(volume_bundle=vdisk_info, api=api)  # Starting to scrub
-                    cls._trigger_mds_issue(vdisk_info, destination_storagedriver.storagerouter.guid, api)  # Trigger mds failover while scrubber is busy
+                    cls._trigger_mds_issue(source_storagedriver.vpool, vdisk_info, destination_storagedriver.storagerouter.guid, api)  # Trigger mds failover while scrubber is busy
                     # Do some monitoring further for 60s
                     ThreadingHandler.keep_threads_running(r_semaphore=io_r_semaphore,
                                                           threads=io_thread_pairs,
@@ -295,7 +295,7 @@ class RegressionTester(CIConstants):
                             vm_data['client'].run(['screen', '-S', screen_name, '-X', 'quit'])
                         vm_data['screen_names'] = []
                     if safety_set is True:
-                        cls._set_mds_safety(len(StorageRouterList.get_masters()), checkup=True)
+                        cls._set_mds_safety(source_storagedriver.vpool, len(StorageRouterList.get_masters()), checkup=True)
         finally:
             cls._adjust_automatic_scrubbing(disable=False)
         assert len(failed_configurations) == 0, 'Certain configuration failed: {0}'.format(' '.join(failed_configurations))
@@ -340,13 +340,13 @@ class RegressionTester(CIConstants):
         return change_scheduled_task(job_key, 'absent')
 
     @staticmethod
-    def _set_mds_safety(safety=None, checkup=False, logger=LOGGER):
+    def _set_mds_safety(vpool, safety=None, checkup=False, logger=LOGGER):
         if safety is None:
             safety = len(StoragerouterHelper.get_storagerouters())
         if safety <= 0:
             raise ValueError('Safety should be at least 1.')
         logger.debug('Setting the safety to {} and {} checkup'.format(safety, 'will' if checkup is True else 'false'))
-        storagedriver_config = Configuration.get('/ovs/framework/storagedriver')
+        storagedriver_config = Configuration.get('/ovs/vpools/{0}/mds_config'.format(vpool.guid))
         current_safety = storagedriver_config
         current_safety['mds_safety'] = safety
         Configuration.set('/ovs/framework/storagedriver', current_safety)
@@ -354,7 +354,7 @@ class RegressionTester(CIConstants):
             MDSServiceController.mds_checkup()
 
     @classmethod
-    def _trigger_mds_issue(cls, volume_bundle, target_storagerouter_guid, api, logger=LOGGER):
+    def _trigger_mds_issue(cls, vpool, volume_bundle, target_storagerouter_guid, api, logger=LOGGER):
         """
         voldrv A, voldrv B, volume X op A
         ensure_safety lopen op X, die gaat master op A en slave op B hebben -> done on create
@@ -367,7 +367,7 @@ class RegressionTester(CIConstants):
         dan gaat 'm opeens B als master gebruiken maar die heeft geen scrub results applied
         """
         logger.debug('Starting the mds triggering.')
-        cls._set_mds_safety(2, checkup=True)  # Will trigger mds checkup which should create a slave again
+        cls._set_mds_safety(vpool, 2, checkup=True)  # Will trigger mds checkup which should create a slave again
         # Move the volume to set the slave as the master
         for vdisk_name, vdisk_object in volume_bundle.iteritems():
             VDiskSetup.move_vdisk(vdisk_guid=vdisk_object.guid, target_storagerouter_guid=target_storagerouter_guid, api=api)


### PR DESCRIPTION
Out[4]: 
({'ci.scenarios.vPool.mds_regression': {'case_type': 'FUNCTIONAL',
   'errors': None,
   'status': 'PASSED'}},
 None)

In [5]: !dpkg -l | grep openvstorage
ii  blktap-openvstorage-ee- 2.0.90-2ubuntu8  amd64            utilities to work with VHD disk images files
ii  libvhd0-openvstorage-ee 2.0.90-2ubuntu8  amd64            VHD file format access library
ii  openvstorage            2.10.3-1         amd64            OpenvStorage
ii  openvstorage-automation 0.4.0-1          amd64            Automation library for OpenvStorage. Contains API wr
ii  openvstorage-backend    1.10.2-1         amd64            OpenvStorage Backend plugin
ii  openvstorage-backend-co 1.10.2-1         amd64            OpenvStorage Backend plugin core
ii  openvstorage-backend-we 1.10.2-1         amd64            OpenvStorage Backend plugin Web Applications
ii  openvstorage-core       2.10.3-1         amd64            OpenvStorage core
ii  openvstorage-extensions 0.2.2-1          amd64            Extensions for Open vStorage
ii  openvstorage-hc         1.10.2-1         amd64            OpenvStorage Backend plugin HyperConverged
ii  openvstorage-health-che 3.6.0-1          amd64            Open vStorage HealthCheck
ii  openvstorage-sdm        1.10.1-1         amd64            Open vStorage Backend ASD Manager
ii  openvstorage-test       3.3.0-1          amd64            openvStorage autotest suite
ii  openvstorage-webapps    2.10.3-1         amd64            OpenvStorage Web Applications
